### PR TITLE
Speedup centos iso image build

### DIFF
--- a/centos7.json
+++ b/centos7.json
@@ -43,6 +43,7 @@
       "vm_name": "centos-7.2-x86_64-server",
       "type": "qemu",
       "format": "qcow2",
+      "disk_cache": "unsafe",
       "accelerator": "kvm",
       "disk_size": "{{ user `disk_size`}}",
 


### PR DESCRIPTION
Use cache=unsafe option to speedup build process.